### PR TITLE
Try to fix flaky API tests in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Check with mypy
         run: docker compose exec test mypy .
       - name: Test with pytest
-        run: docker compose exec test pytest
+        run: docker compose exec test pytest || (docker compose logs sertifikatsok && return 1)

--- a/api/sertifikatsok/web.py
+++ b/api/sertifikatsok/web.py
@@ -64,6 +64,11 @@ async def handle_exception(request: Request, exc: Exception) -> Response:
         ),
         status_code=500,
         media_type="application/json",
+        # Stuff caught by a general `Exception` handler
+        # bubbles all the way up to Uvicorn, which closes
+        # the connection after the response is sent. So
+        # add a matching Connection header.
+        headers={"Connection": "close"},
     )
 
 

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -15,7 +15,3 @@ def test_known_cert_types_subject_matches_trusted_cert() -> None:
     ]
     for name, _ in KNOWN_CERT_TYPES:
         assert name in all_trusted_subjects
-
-
-def test_fail() -> None:
-    assert not True

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -15,3 +15,7 @@ def test_known_cert_types_subject_matches_trusted_cert() -> None:
     ]
     for name, _ in KNOWN_CERT_TYPES:
         assert name in all_trusted_subjects
+
+
+def test_fail() -> None:
+    assert not True


### PR DESCRIPTION
Uvicorn closes the connection after our 500 errors. So the theory is that the httpx client in the api tests sometimes tries to reuse that connection before it is actually shut down, and then ends up with a ReadError. Add a matching `Connection: close` header so that httpx (hopefully) understands that the connection is not for reuse.